### PR TITLE
IA-790, IA-793 fix IconButton can receive any icon, fade when disabled

### DIFF
--- a/dist/components/buttons/IconButton/index.js
+++ b/dist/components/buttons/IconButton/index.js
@@ -98,7 +98,8 @@ var styles = function styles(theme) {
 var ButtonIcon = function ButtonIcon(_ref) {
   var Icon = _ref.icon,
       color = _ref.color,
-      onClick = _ref.onClick;
+      onClick = _ref.onClick,
+      disabled = _ref.disabled;
 
   if (Icon === undefined) {
     return 'wrong icon';
@@ -108,9 +109,11 @@ var ButtonIcon = function ButtonIcon(_ref) {
     onClick: onClick
   } : {}; // special override for white color, which is not a "theme" variant such as primary, secondary or action
 
-  var iconStyles = color === 'white' ? {
-    color: 'white'
-  } : {};
+  var iconStyles = {
+    color: color === 'white' ? color : undefined,
+    opacity: disabled ? 0.5 : 1
+  }; // const iconStyles = color === 'white' ? { color: 'white' } : {};
+
   return /*#__PURE__*/_react["default"].createElement(Icon, _extends({}, iconProps, {
     color: color === 'white' ? 'inherit' : color,
     style: iconStyles
@@ -118,12 +121,14 @@ var ButtonIcon = function ButtonIcon(_ref) {
 };
 
 ButtonIcon.defaultProps = {
-  onClick: null
+  onClick: null,
+  disabled: false
 };
 ButtonIcon.propTypes = {
   onClick: _propTypes["default"].func,
   icon: _propTypes["default"].oneOfType([_propTypes["default"].object, _propTypes["default"].func]).isRequired,
-  color: _propTypes["default"].string.isRequired
+  color: _propTypes["default"].string.isRequired,
+  disabled: _propTypes["default"].bool
 };
 
 function IconButtonComponent(_ref2) {
@@ -169,7 +174,8 @@ function IconButtonComponent(_ref2) {
     color: color
   })) : /*#__PURE__*/_react["default"].createElement(ButtonIcon, {
     icon: icon,
-    color: color
+    color: color,
+    disabled: disabled
   }))));
 }
 

--- a/dist/components/buttons/IconButton/index.js
+++ b/dist/components/buttons/IconButton/index.js
@@ -132,6 +132,7 @@ function IconButtonComponent(_ref2) {
       onClick = _ref2.onClick,
       url = _ref2.url,
       iconName = _ref2.icon,
+      overrideIcon = _ref2.overrideIcon,
       tooltipMessage = _ref2.tooltipMessage,
       color = _ref2.color,
       size = _ref2.size;
@@ -140,8 +141,13 @@ function IconButtonComponent(_ref2) {
     console.error('IconButtonComponent needs either the onClick or the url property');
   }
 
+  if (!iconName && !overrideIcon) {
+    console.error('IconButtonComponent has to be provided with an icon');
+  }
+
   var Link = (0, _LinkProvider.useLink)();
-  var icon = ICON_VARIANTS[iconName]; // FIXME Why the <span>????
+  var icon = overrideIcon !== null && overrideIcon !== void 0 ? overrideIcon : ICON_VARIANTS[iconName];
+  console.log('icon', overrideIcon, icon); // FIXME Why the <span>????
 
   return /*#__PURE__*/_react["default"].createElement(_core.Tooltip, {
     classes: {
@@ -173,7 +179,9 @@ IconButtonComponent.defaultProps = {
   url: null,
   onClick: null,
   color: 'action',
-  size: 'medium'
+  size: 'medium',
+  overrideIcon: null,
+  icon: null
 };
 IconButtonComponent.propTypes = {
   size: _propTypes["default"].string,
@@ -181,8 +189,9 @@ IconButtonComponent.propTypes = {
   onClick: _propTypes["default"].func,
   url: _propTypes["default"].string,
   disabled: _propTypes["default"].bool,
-  icon: _propTypes["default"].oneOf(Object.keys(ICON_VARIANTS)).isRequired,
+  icon: _propTypes["default"].oneOf(Object.keys(ICON_VARIANTS)),
   color: _propTypes["default"].string,
+  overrideIcon: _propTypes["default"].node,
   tooltipMessage: _propTypes["default"].object.isRequired // TODO: refactor IASO to pass the translation directly
 
 };

--- a/dist/components/buttons/IconButton/index.js
+++ b/dist/components/buttons/IconButton/index.js
@@ -191,7 +191,7 @@ IconButtonComponent.propTypes = {
   disabled: _propTypes["default"].bool,
   icon: _propTypes["default"].oneOf(Object.keys(ICON_VARIANTS)),
   color: _propTypes["default"].string,
-  overrideIcon: _propTypes["default"].node,
+  overrideIcon: _propTypes["default"].any,
   tooltipMessage: _propTypes["default"].object.isRequired // TODO: refactor IASO to pass the translation directly
 
 };

--- a/dist/components/buttons/IconButton/index.js
+++ b/dist/components/buttons/IconButton/index.js
@@ -146,8 +146,7 @@ function IconButtonComponent(_ref2) {
   }
 
   var Link = (0, _LinkProvider.useLink)();
-  var icon = overrideIcon !== null && overrideIcon !== void 0 ? overrideIcon : ICON_VARIANTS[iconName];
-  console.log('icon', overrideIcon, icon); // FIXME Why the <span>????
+  var icon = overrideIcon !== null && overrideIcon !== void 0 ? overrideIcon : ICON_VARIANTS[iconName]; // FIXME Why the <span>????
 
   return /*#__PURE__*/_react["default"].createElement(_core.Tooltip, {
     classes: {

--- a/src/components/buttons/IconButton/index.js
+++ b/src/components/buttons/IconButton/index.js
@@ -105,7 +105,6 @@ function IconButtonComponent({
     }
     const Link = useLink();
     const icon = overrideIcon ?? ICON_VARIANTS[iconName];
-    console.log('icon', overrideIcon, icon);
     // FIXME Why the <span>????
     return (
         <Tooltip

--- a/src/components/buttons/IconButton/index.js
+++ b/src/components/buttons/IconButton/index.js
@@ -57,7 +57,7 @@ const styles = theme => ({
     },
 });
 
-const ButtonIcon = ({ icon: Icon, color, onClick }) => {
+const ButtonIcon = ({ icon: Icon, color, onClick, disabled }) => {
     if (Icon === undefined) {
         return 'wrong icon';
     }
@@ -65,7 +65,11 @@ const ButtonIcon = ({ icon: Icon, color, onClick }) => {
     const iconProps = onClick !== null ? { onClick } : {};
 
     // special override for white color, which is not a "theme" variant such as primary, secondary or action
-    const iconStyles = color === 'white' ? { color: 'white' } : {};
+    const iconStyles = {
+        color: color === 'white' ? color : undefined,
+        opacity: disabled ? 0.5 : 1,
+    };
+    // const iconStyles = color === 'white' ? { color: 'white' } : {};
 
     return (
         <Icon
@@ -77,11 +81,13 @@ const ButtonIcon = ({ icon: Icon, color, onClick }) => {
 };
 ButtonIcon.defaultProps = {
     onClick: null,
+    disabled: false,
 };
 ButtonIcon.propTypes = {
     onClick: PropTypes.func,
     icon: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
     color: PropTypes.string.isRequired,
+    disabled: PropTypes.bool,
 };
 
 function IconButtonComponent({
@@ -122,7 +128,11 @@ function IconButtonComponent({
                             <ButtonIcon icon={icon} color={color} />
                         </Link>
                     ) : (
-                        <ButtonIcon icon={icon} color={color} />
+                        <ButtonIcon
+                            icon={icon}
+                            color={color}
+                            disabled={disabled}
+                        />
                     )}
                 </IconButton>
             </span>

--- a/src/components/buttons/IconButton/index.js
+++ b/src/components/buttons/IconButton/index.js
@@ -147,7 +147,7 @@ IconButtonComponent.propTypes = {
     disabled: PropTypes.bool,
     icon: PropTypes.oneOf(Object.keys(ICON_VARIANTS)),
     color: PropTypes.string,
-    overrideIcon: PropTypes.node,
+    overrideIcon: PropTypes.any,
     tooltipMessage: PropTypes.object.isRequired, // TODO: refactor IASO to pass the translation directly
 };
 

--- a/src/components/buttons/IconButton/index.js
+++ b/src/components/buttons/IconButton/index.js
@@ -90,6 +90,7 @@ function IconButtonComponent({
     onClick,
     url,
     icon: iconName,
+    overrideIcon,
     tooltipMessage,
     color,
     size,
@@ -99,8 +100,12 @@ function IconButtonComponent({
             'IconButtonComponent needs either the onClick or the url property',
         );
     }
+    if (!iconName && !overrideIcon) {
+        console.error('IconButtonComponent has to be provided with an icon');
+    }
     const Link = useLink();
-    const icon = ICON_VARIANTS[iconName];
+    const icon = overrideIcon ?? ICON_VARIANTS[iconName];
+    console.log('icon', overrideIcon, icon);
     // FIXME Why the <span>????
     return (
         <Tooltip
@@ -131,6 +136,8 @@ IconButtonComponent.defaultProps = {
     onClick: null,
     color: 'action',
     size: 'medium',
+    overrideIcon: null,
+    icon: null,
 };
 IconButtonComponent.propTypes = {
     size: PropTypes.string,
@@ -138,8 +145,9 @@ IconButtonComponent.propTypes = {
     onClick: PropTypes.func,
     url: PropTypes.string,
     disabled: PropTypes.bool,
-    icon: PropTypes.oneOf(Object.keys(ICON_VARIANTS)).isRequired,
+    icon: PropTypes.oneOf(Object.keys(ICON_VARIANTS)),
     color: PropTypes.string,
+    overrideIcon: PropTypes.node,
     tooltipMessage: PropTypes.object.isRequired, // TODO: refactor IASO to pass the translation directly
 };
 


### PR DESCRIPTION
## Changes

- added `overrideIcon` prop to that can receive a custom icon
- made `icon` props optional
- error if both `icon` and `overrideIcon` are null/undefined
- Reduce opacity to 0.5 when disabled (IA-791)