### PR TITLE
IA-795 fix: leave options list open on multiselect

### DIFF
--- a/dist/components/buttons/IconButton/index.js
+++ b/dist/components/buttons/IconButton/index.js
@@ -151,7 +151,7 @@ function IconButtonComponent(_ref2) {
   }
 
   var Link = (0, _LinkProvider.useLink)();
-  var icon = overrideIcon !== null && overrideIcon !== void 0 ? overrideIcon : ICON_VARIANTS[iconName]; // FIXME Why the <span>????
+  var icon = overrideIcon !== null && overrideIcon !== void 0 ? overrideIcon : ICON_VARIANTS[iconName]; // The <span> is needed so the tooltip correctly display when the button is disabled
 
   return /*#__PURE__*/_react["default"].createElement(_core.Tooltip, {
     classes: {

--- a/dist/components/inputs/Select/index.js
+++ b/dist/components/inputs/Select/index.js
@@ -156,6 +156,7 @@ var SelectCustom = function SelectCustom(_ref) {
   }, /*#__PURE__*/_react["default"].createElement(_Autocomplete["default"], _extends({
     noOptionsText: intl.formatMessage(noOptionsText),
     multiple: multi,
+    disableCloseOnSelect: multi,
     id: keyValue,
     disableClearable: !clearable,
     options: options,

--- a/src/components/inputs/Select/index.js
+++ b/src/components/inputs/Select/index.js
@@ -123,6 +123,7 @@ const SelectCustom = ({
             <Autocomplete
                 noOptionsText={intl.formatMessage(noOptionsText)}
                 multiple={multi}
+                disableCloseOnSelect={multi}
                 id={keyValue}
                 disableClearable={!clearable}
                 options={options}


### PR DESCRIPTION
## Changes
- added `disableCloseOnSelect={multi}` in `Select` component



https://user-images.githubusercontent.com/38907762/133975480-69463793-163e-4698-ac72-18204193790c.mov

original issue: https://bluesquare.atlassian.net/browse/IA-795