### PR TITLE
IA-795 keep select dropdown visible with shift

### DIFF
--- a/dist/components/inputs/Select/index.js
+++ b/dist/components/inputs/Select/index.js
@@ -27,6 +27,8 @@ var _messages = require("./messages");
 
 var _styles = require("../styles");
 
+var _useKeyPressListener = require("../../../utils/useKeyPressListener");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -61,6 +63,7 @@ var SelectCustom = function SelectCustom(_ref) {
       renderOption = _ref.renderOption;
   var intl = (0, _useSafeIntl.useSafeIntl)();
   var classes = (0, _styles.useStyles)();
+  var shiftKeyIsDown = (0, _useKeyPressListener.useKeyPressListener)('Shift');
 
   var getOption = function getOption(optionValue) {
     return options.find(function (o) {
@@ -155,8 +158,8 @@ var SelectCustom = function SelectCustom(_ref) {
     mb: 2
   }, /*#__PURE__*/_react["default"].createElement(_Autocomplete["default"], _extends({
     noOptionsText: intl.formatMessage(noOptionsText),
-    multiple: multi // disableCloseOnSelect={multi}
-    ,
+    multiple: multi,
+    disableCloseOnSelect: multi && shiftKeyIsDown,
     id: keyValue,
     disableClearable: !clearable,
     options: options,

--- a/dist/components/table/Table/index.js
+++ b/dist/components/table/Table/index.js
@@ -47,6 +47,8 @@ var _Pagination = require("./Pagination");
 
 var _LoadingSpinner = require("../../LoadingSpinner");
 
+var _useKeyPressListener = require("../../../utils/useKeyPressListener");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -65,21 +67,13 @@ function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableTo
 
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
 function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 /**
  * TableComponent component, no redux, no fetch, just displaying.
@@ -150,12 +144,7 @@ var TableComponent = function TableComponent(props) {
       formatMessage = _useSafeIntl.formatMessage;
 
   var classes = useStyles();
-
-  var _useState = (0, _react.useState)(false),
-      _useState2 = _slicedToArray(_useState, 2),
-      multiSortEnabled = _useState2[0],
-      setMultiSortEnabled = _useState2[1];
-
+  var multiSortEnabled = (0, _useKeyPressListener.useKeyPressListener)('Shift');
   var columns = (0, _react.useMemo)(function () {
     var temp = _toConsumableArray(props.columns);
 
@@ -227,31 +216,6 @@ var TableComponent = function TableComponent(props) {
     redirectTo(baseUrl, newParams);
     onTableParamsChange(newParams);
   };
-
-  (0, _react.useEffect)(function () {
-    var handleSetMultiSortEnabled = function handleSetMultiSortEnabled(e, enabled) {
-      if (e.key === 'Shift') {
-        setMultiSortEnabled(enabled);
-      }
-    };
-
-    var setOn = function setOn(e) {
-      handleSetMultiSortEnabled(e, true);
-    };
-
-    var setOff = function setOff(e) {
-      handleSetMultiSortEnabled(e, false);
-    };
-
-    document.addEventListener('keydown', setOn);
-    document.addEventListener('keyup', setOff);
-    document.addEventListener('onBlur', setOff);
-    return function () {
-      document.removeEventListener('keydown', setOn);
-      document.removeEventListener('keyup', setOff);
-      document.removeEventListener('onBlur', setOff);
-    };
-  }, [multiSortEnabled]);
 
   var tableProps = _objectSpread(_objectSpread({}, getTableProps()), {}, {
     size: 'small'

--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,8 @@ var _exportNames = {
   SingleComment: true,
   CommentWithThread: true,
   AddComment: true,
-  InputLabel: true
+  InputLabel: true,
+  useKeyPressListener: true
 };
 Object.defineProperty(exports, "LoadingSpinner", {
   enumerable: true,
@@ -346,6 +347,12 @@ Object.defineProperty(exports, "InputLabel", {
     return _InputLabel.InputLabel;
   }
 });
+Object.defineProperty(exports, "useKeyPressListener", {
+  enumerable: true,
+  get: function get() {
+    return _useKeyPressListener.useKeyPressListener;
+  }
+});
 exports.IasoUiConstants = exports.SnackBar = exports.IasoChipColors = void 0;
 
 var _LoadingSpinner = require("./components/LoadingSpinner");
@@ -458,6 +465,8 @@ var _CommentWithThread = require("./components/comments/CommentWithThread");
 var _AddComment = require("./components/comments/AddComment");
 
 var _InputLabel = require("./components/inputs/InputLabel");
+
+var _useKeyPressListener = require("./utils/useKeyPressListener");
 
 var _utils = require("./utils");
 

--- a/dist/utils/useKeyPressListener.js
+++ b/dist/utils/useKeyPressListener.js
@@ -1,0 +1,55 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.useKeyPressListener = void 0;
+
+var _react = require("react");
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+var useKeyPressListener = function useKeyPressListener(key) {
+  var _useState = (0, _react.useState)(false),
+      _useState2 = _slicedToArray(_useState, 2),
+      isEnabled = _useState2[0],
+      setIsEnabled = _useState2[1];
+
+  (0, _react.useEffect)(function () {
+    var enableListeners = function enableListeners(e, toggle) {
+      if (e.key === key) {
+        setIsEnabled(toggle);
+      }
+    };
+
+    var enable = function enable(e) {
+      enableListeners(e, true);
+    };
+
+    var disable = function disable(e) {
+      enableListeners(e, false);
+    };
+
+    document.addEventListener('keydown', enable);
+    document.addEventListener('keyup', disable);
+    document.addEventListener('blur', disable);
+    return function () {
+      document.removeEventListener('keydown', enable);
+      document.removeEventListener('keyup', disable);
+      document.removeEventListener('blur', disable);
+    };
+  }, [isEnabled]);
+  return isEnabled;
+};
+
+exports.useKeyPressListener = useKeyPressListener;

--- a/src/components/inputs/Select/index.js
+++ b/src/components/inputs/Select/index.js
@@ -8,6 +8,7 @@ import { CircularProgress } from '@material-ui/core';
 import { useSafeIntl } from '../../../utils/useSafeIntl';
 import { MESSAGES } from './messages';
 import { useStyles } from '../styles';
+import { useKeyPressListener } from '../../../utils/useKeyPressListener';
 
 const SelectCustom = ({
     value,
@@ -30,6 +31,7 @@ const SelectCustom = ({
 }) => {
     const intl = useSafeIntl();
     const classes = useStyles();
+    const shiftKeyIsDown = useKeyPressListener('Shift');
 
     const getOption = optionValue =>
         options.find(o => `${o.value}` === `${optionValue}`);
@@ -117,13 +119,12 @@ const SelectCustom = ({
             />
         );
     };
-
     return (
         <Box mt={1} mb={2}>
             <Autocomplete
                 noOptionsText={intl.formatMessage(noOptionsText)}
                 multiple={multi}
-                // disableCloseOnSelect={multi}
+                disableCloseOnSelect={multi && shiftKeyIsDown}
                 id={keyValue}
                 disableClearable={!clearable}
                 options={options}

--- a/src/components/table/Table/index.js
+++ b/src/components/table/Table/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import MuiTable from '@material-ui/core/Table';
@@ -35,6 +35,7 @@ import { NoResult } from './NoResult';
 import { Count } from './Count';
 import { Pagination } from './Pagination';
 import { LoadingSpinner } from '../../LoadingSpinner';
+import { useKeyPressListener } from '../../../utils/useKeyPressListener';
 /**
  * TableComponent component, no redux, no fetch, just displaying.
  * Multi selection is optionnal, if set to true you can add custom actions
@@ -102,7 +103,7 @@ const TableComponent = props => {
     const { formatMessage } = useSafeIntl();
     const classes = useStyles();
 
-    const [multiSortEnabled, setMultiSortEnabled] = useState(false);
+    const multiSortEnabled = useKeyPressListener('Shift');
 
     const columns = useMemo(() => {
         const temp = [...props.columns];
@@ -191,32 +192,11 @@ const TableComponent = props => {
         onTableParamsChange(newParams);
     };
 
-    useEffect(() => {
-        const handleSetMultiSortEnabled = (e, enabled) => {
-            if (e.key === 'Shift') {
-                setMultiSortEnabled(enabled);
-            }
-        };
-        const setOn = e => {
-            handleSetMultiSortEnabled(e, true);
-        };
-        const setOff = e => {
-            handleSetMultiSortEnabled(e, false);
-        };
-        document.addEventListener('keydown', setOn);
-        document.addEventListener('keyup', setOff);
-        document.addEventListener('onBlur', setOff);
-        return () => {
-            document.removeEventListener('keydown', setOn);
-            document.removeEventListener('keyup', setOff);
-            document.removeEventListener('onBlur', setOff);
-        };
-    }, [multiSortEnabled]);
-
     const tableProps = {
         ...getTableProps(),
         size: 'small',
     };
+
     const rowsPerPage = parseInt(pageSize, 10);
     return (
         <Box mt={marginTop ? 4 : 0} mb={4}>

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ import { SingleComment } from './components/comments/SingleComment';
 import { CommentWithThread } from './components/comments/CommentWithThread';
 import { AddComment } from './components/comments/AddComment';
 import { InputLabel } from './components/inputs/InputLabel';
+import { useKeyPressListener } from './utils/useKeyPressListener';
 
 export * from './utils';
 export * from './utils/intlUtils';
@@ -110,4 +111,5 @@ export {
     InputLabel,
     Expander,
     FormControl,
+    useKeyPressListener,
 };

--- a/src/utils/useKeyPressListener.js
+++ b/src/utils/useKeyPressListener.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+export const useKeyPressListener = key => {
+    const [isEnabled, setIsEnabled] = useState(false);
+    useEffect(() => {
+        const enableListeners = (e, toggle) => {
+            if (e.key === key) {
+                setIsEnabled(toggle);
+            }
+        };
+        const enable = e => {
+            enableListeners(e, true);
+        };
+        const disable = e => {
+            enableListeners(e, false);
+        };
+        document.addEventListener('keydown', enable);
+        document.addEventListener('keyup', disable);
+        document.addEventListener('blur', disable);
+        return () => {
+            document.removeEventListener('keydown', enable);
+            document.removeEventListener('keyup', disable);
+            document.removeEventListener('blur', disable);
+        };
+    }, [isEnabled]);
+
+    return isEnabled;
+};


### PR DESCRIPTION
## Changes
- Added `useKeyPressListener` hook, that will listen for a specific key to be pressed and return a boolean accordingly
- Used the hook to set the value of `AutoComplete`'s `disableCloseOnSelect` prop
- Replaced effect in `Table` with `useKeyPressListener`

https://user-images.githubusercontent.com/38907762/134188635-3bf25868-54be-4264-bb61-c3c30d806ee4.mov



