### PR TITLE
fix patchIntl not passing the value params

### DIFF
--- a/src/utils/patchIntl.js
+++ b/src/utils/patchIntl.js
@@ -1,9 +1,8 @@
-const patchIntl = intl => {
-    const intlCopy = { ...intl };
-    const intlOriginal = { ...intl };
-    const formatMessage = message => {
-        if (message && message.id && message.defaultMessage) {
-            return intlOriginal.formatMessage(message);
+const patchIntl = intl => ({
+    ...intl,
+    formatMessage: (message, value) => {
+        if (message && message.id) {
+            return intl.formatMessage(message, value);
         }
         console.warn(
             'Warning: Message object is not defined properly!',
@@ -11,9 +10,7 @@ const patchIntl = intl => {
         );
 
         return null;
-    };
-    intlCopy.formatMessage = formatMessage;
-    return intlCopy;
-};
+    },
+});
 
 export { patchIntl };


### PR DESCRIPTION
the patched formatMessage was not passing the value argument
make formatMessage with no defaultMessage (which is accepted by react-intl)
and don't make superflous copy of the object