### PR TITLE
Memoise useSafeIntl

### DIFF
--- a/src/components/inputs/Select/index.js
+++ b/src/components/inputs/Select/index.js
@@ -65,7 +65,7 @@ const SelectCustom = ({
                 }
                 return valuesList.map(v => getOption(v)).filter(o => o);
             }
-            return getOption(value);
+            return getOption(value) ?? value;
         }
         return multi ? [] : null;
     }, [value, options, multi]);
@@ -85,7 +85,7 @@ const SelectCustom = ({
         [multi, onChange, returnFullObject],
     );
     const extraProps = {
-        getOptionLabel: getOptionLabel || (option => option && option.label),
+        getOptionLabel: getOptionLabel || (option => option?.label || option),
         getOptionSelected:
             getOptionSelected ||
             ((option, val) => val && option.value === val.value),

--- a/src/utils/useSafeIntl.js
+++ b/src/utils/useSafeIntl.js
@@ -1,4 +1,10 @@
+import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { patchIntl } from './patchIntl';
 
-export const useSafeIntl = () => patchIntl(useIntl());
+export const useSafeIntl = () => {
+    const intl = useIntl();
+    // noinspection UnnecessaryLocalVariableJS
+    const patchedIntl = useMemo(() => patchIntl(intl), [intl]);
+    return patchedIntl;
+};


### PR DESCRIPTION
previously it was not memoized, so when we used it as a dep for useMemo and useCallback
these were always called.

e.g. In the column calculation on the column page, when the dialog was opened, the useMemo for the column changed
and the whole table was compaed and it took two seconds to display the dialog, leaving a hanging effect.
It now takes 0.5s to display the dialog which is still on the long side but less perceptible by the user