### PR TITLE
IA-937 add resetToPageOne prop to Table

### DIFF
--- a/dist/components/table/Table/index.js
+++ b/dist/components/table/Table/index.js
@@ -138,7 +138,8 @@ var TableComponent = function TableComponent(props) {
       showPagination = props.showPagination,
       showFooter = props.showFooter,
       onTableParamsChange = props.onTableParamsChange,
-      defaultSorted = props.defaultSorted;
+      defaultSorted = props.defaultSorted,
+      resetPageToOne = props.resetPageToOne;
 
   var _useSafeIntl = (0, _useSafeIntl2.useSafeIntl)(),
       formatMessage = _useSafeIntl.formatMessage;
@@ -221,6 +222,9 @@ var TableComponent = function TableComponent(props) {
     size: 'small'
   });
 
+  (0, _react.useEffect)(function () {
+    gotoPage(0);
+  }, [resetPageToOne]);
   var rowsPerPage = parseInt(pageSize, 10);
   return /*#__PURE__*/_react["default"].createElement(_Box["default"], {
     mt: marginTop ? 4 : 0,
@@ -302,7 +306,8 @@ TableComponent.defaultProps = {
   onTableParamsChange: function onTableParamsChange() {
     return null;
   },
-  defaultSorted: (0, _tableUtils.getOrderArray)(_constants.DEFAULT_ORDER)
+  defaultSorted: (0, _tableUtils.getOrderArray)(_constants.DEFAULT_ORDER),
+  resetPageToOne: ''
 };
 TableComponent.propTypes = {
   params: _propTypes["default"].object,
@@ -324,7 +329,8 @@ TableComponent.propTypes = {
   showPagination: _propTypes["default"].bool,
   showFooter: _propTypes["default"].bool,
   onTableParamsChange: _propTypes["default"].func,
-  defaultSorted: _propTypes["default"].array
+  defaultSorted: _propTypes["default"].array,
+  resetPageToOne: _propTypes["default"].string
 };
 
 var Table = /*#__PURE__*/_react["default"].memo(TableComponent, function (props, prevProps) {

--- a/src/components/table/Table/index.js
+++ b/src/components/table/Table/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import MuiTable from '@material-ui/core/Table';
@@ -99,6 +99,7 @@ const TableComponent = props => {
         showFooter,
         onTableParamsChange,
         defaultSorted,
+        resetPageToOne,
     } = props;
     const { formatMessage } = useSafeIntl();
     const classes = useStyles();
@@ -197,6 +198,10 @@ const TableComponent = props => {
         size: 'small',
     };
 
+    useEffect(() => {
+        gotoPage(0);
+    }, [resetPageToOne]);
+
     const rowsPerPage = parseInt(pageSize, 10);
     return (
         <Box mt={marginTop ? 4 : 0} mb={4}>
@@ -275,6 +280,7 @@ TableComponent.defaultProps = {
     showFooter: false,
     onTableParamsChange: () => null,
     defaultSorted: getOrderArray(DEFAULT_ORDER),
+    resetPageToOne: '',
 };
 
 TableComponent.propTypes = {
@@ -298,6 +304,7 @@ TableComponent.propTypes = {
     showFooter: PropTypes.bool,
     onTableParamsChange: PropTypes.func,
     defaultSorted: PropTypes.array,
+    resetPageToOne: PropTypes.string,
 };
 
 const Table = React.memo(TableComponent, (props, prevProps) => {


### PR DESCRIPTION
## Changes

- add `resetToPageOne`prop to the `Table`. It takes a string and the active page will be set to 1 in the `Pagination` when the string changes. 

We need to pass an additional prop, as the `Table`has no way of knowing whether a change in `data` is due to a page change or to a change in the call itself( eg: a new search in the parent component).