### PR TITLE
IA 1078: make treeview items selectable/unselectable

### DIFF
--- a/dist/components/Treeview/EnrichedTreeItem.js
+++ b/dist/components/Treeview/EnrichedTreeItem.js
@@ -187,6 +187,7 @@ var EnrichedTreeItem = function EnrichedTreeItem(_ref) {
     }, childrenData && isExpanded && makeSubTree(childrenData), !isExpanded && /*#__PURE__*/_react["default"].createElement("div", null)));
   }
 
+  if (!hasChildren && !isSelectable) return null;
   return /*#__PURE__*/_react["default"].createElement("div", {
     style: {
       display: 'flex'

--- a/dist/components/Treeview/EnrichedTreeItem.js
+++ b/dist/components/Treeview/EnrichedTreeItem.js
@@ -38,7 +38,14 @@ var styles = function styles(theme) {
     treeItem: {
       '&.MuiTreeItem-root.Mui-selected > .MuiTreeItem-content .MuiTreeItem-label': {
         backgroundColor: theme.palette.primary.background,
-        alignItems: 'center'
+        alignItems: 'center',
+        color: theme.palette.primary.main
+      }
+    },
+    unselectableTreeItem: {
+      '&.MuiTreeItem-root > .MuiTreeItem-content .MuiTreeItem-label': {
+        alignItems: 'center',
+        color: theme.palette.mediumGray.main
       }
     },
     checkbox: {
@@ -62,11 +69,13 @@ var EnrichedTreeItem = function EnrichedTreeItem(_ref) {
       withCheckbox = _ref.withCheckbox,
       ticked = _ref.ticked,
       parentsTicked = _ref.parentsTicked,
-      scrollIntoView = _ref.scrollIntoView;
+      scrollIntoView = _ref.scrollIntoView,
+      allowSelection = _ref.allowSelection;
   var classes = useStyles();
   var isExpanded = expanded.includes(id);
   var isTicked = ticked.includes(id);
   var isTickedParent = parentsTicked.includes(id);
+  var isSelectable = allowSelection(data);
 
   var _useChildrenData = (0, _requests.useChildrenData)({
     request: fetchChildrenData,
@@ -107,8 +116,8 @@ var EnrichedTreeItem = function EnrichedTreeItem(_ref) {
       e.preventDefault();
     }
 
-    onLabelClick(id, data);
-  }, [data, id, onLabelClick, toggleOnLabelClick]);
+    onLabelClick(id, data, isSelectable);
+  }, [data, id, onLabelClick, toggleOnLabelClick, isSelectable]);
   (0, _react.useEffect)(function () {
     if (scrollIntoView === id) {
       ref.current.scrollIntoView();
@@ -130,7 +139,8 @@ var EnrichedTreeItem = function EnrichedTreeItem(_ref) {
         withCheckbox: withCheckbox,
         ticked: ticked,
         parentsTicked: parentsTicked,
-        scrollIntoView: scrollIntoView
+        scrollIntoView: scrollIntoView,
+        allowSelection: allowSelection
       });
     });
   };
@@ -138,7 +148,7 @@ var EnrichedTreeItem = function EnrichedTreeItem(_ref) {
   if (isExpanded && isLoading) {
     return /*#__PURE__*/_react["default"].createElement(_lab.TreeItem, {
       classes: {
-        root: classes.treeItem
+        root: isSelectable ? classes.treeItem : classes.unselectableTreeItem
       },
       ref: ref,
       label: makeLabel(label(data), withCheckbox, isTicked, isTickedParent),
@@ -158,7 +168,7 @@ var EnrichedTreeItem = function EnrichedTreeItem(_ref) {
       }
     }, /*#__PURE__*/_react["default"].createElement(_lab.TreeItem, {
       classes: {
-        root: classes.treeItem
+        root: isSelectable ? classes.treeItem : classes.unselectableTreeItem
       },
       ref: ref,
       label: makeLabel(label(data), withCheckbox, isTicked, isTickedParent),
@@ -183,7 +193,7 @@ var EnrichedTreeItem = function EnrichedTreeItem(_ref) {
     }
   }, /*#__PURE__*/_react["default"].createElement(_lab.TreeItem, {
     classes: {
-      root: classes.treeItem
+      root: isSelectable ? classes.treeItem : classes.unselectableTreeItem
     },
     ref: ref,
     label: makeLabel(label(data), withCheckbox, isTicked),
@@ -214,7 +224,8 @@ EnrichedTreeItem.propTypes = {
   withCheckbox: _propTypes.bool,
   ticked: (0, _propTypes.oneOfType)([_propTypes.string, _propTypes.array]),
   parentsTicked: _propTypes.array,
-  scrollIntoView: _propTypes.string
+  scrollIntoView: _propTypes.string,
+  allowSelection: _propTypes.func
 };
 EnrichedTreeItem.defaultProps = {
   fetchChildrenData: function fetchChildrenData() {},
@@ -224,5 +235,8 @@ EnrichedTreeItem.defaultProps = {
   withCheckbox: false,
   ticked: [],
   parentsTicked: [],
-  scrollIntoView: null
+  scrollIntoView: null,
+  allowSelection: function allowSelection() {
+    return true;
+  }
 };

--- a/dist/components/Treeview/IasoTreeView.js
+++ b/dist/components/Treeview/IasoTreeView.js
@@ -60,7 +60,8 @@ var IasoTreeView = function IasoTreeView(_ref) {
       onLabelClick = _ref.onLabelClick,
       ticked = _ref.ticked,
       parentsTicked = _ref.parentsTicked,
-      scrollIntoView = _ref.scrollIntoView;
+      scrollIntoView = _ref.scrollIntoView,
+      allowSelection = _ref.allowSelection;
   var classes = useStyles();
   var fetchChildrenData = (0, _react.useCallback)(getChildrenData, [getChildrenData]);
 
@@ -93,7 +94,8 @@ var IasoTreeView = function IasoTreeView(_ref) {
         withCheckbox: multiselect,
         ticked: ticked,
         parentsTicked: parentsTicked,
-        scrollIntoView: scrollIntoView
+        scrollIntoView: scrollIntoView,
+        allowSelection: allowSelection
       });
     });
   }, [label, fetchChildrenData, expanded, selected, toggleOnLabelClick, onCheckBoxClick, onLabelClick, multiselect, ticked, parentsTicked, scrollIntoView]);
@@ -132,7 +134,8 @@ IasoTreeView.propTypes = {
   selected: (0, _propTypes.oneOfType)([_propTypes.string, (0, _propTypes.arrayOf)(_propTypes.string)]),
   ticked: (0, _propTypes.oneOfType)([_propTypes.string, (0, _propTypes.arrayOf)(_propTypes.string)]),
   parentsTicked: _propTypes.array,
-  scrollIntoView: _propTypes.string
+  scrollIntoView: _propTypes.string,
+  allowSelection: _propTypes.func
 };
 IasoTreeView.defaultProps = {
   getChildrenData: function getChildrenData() {},
@@ -145,5 +148,8 @@ IasoTreeView.defaultProps = {
   selected: undefined,
   ticked: [],
   parentsTicked: [],
-  scrollIntoView: null
+  scrollIntoView: null,
+  allowSelection: function allowSelection() {
+    return true;
+  }
 };

--- a/dist/components/Treeview/TreeViewWithSearch.js
+++ b/dist/components/Treeview/TreeViewWithSearch.js
@@ -68,7 +68,8 @@ var TreeViewWithSearch = function TreeViewWithSearch(_ref) {
       multiselect = _ref.multiselect,
       preselected = _ref.preselected,
       preexpanded = _ref.preexpanded,
-      selectedData = _ref.selectedData;
+      selectedData = _ref.selectedData,
+      allowSelection = _ref.allowSelection;
 
   var _useState = (0, _react.useState)(formatInitialSelectedData(selectedData)),
       _useState2 = _slicedToArray(_useState, 2),
@@ -109,22 +110,30 @@ var TreeViewWithSearch = function TreeViewWithSearch(_ref) {
     }
   }, [onSelect, multiselect]); // Tick and untick checkbox
 
-  var onLabelClick = (0, _react.useCallback)(function (id, itemData) {
+  var onLabelClick = (0, _react.useCallback)(function (id, itemData, isSelectable) {
     var newTicked;
     var updatedParents;
     var updatedSelectedData;
 
-    if (multiselect) {
-      newTicked = ticked.includes(id) ? ticked.filter(function (tickedId) {
-        return tickedId !== id;
-      }) : [].concat(_toConsumableArray(ticked), [id]);
-      updatedParents = new Map(parentsTicked);
-    } else {
-      newTicked = [id];
-      updatedParents = new Map();
+    if (isSelectable) {
+      console.log('OK');
+
+      if (multiselect) {
+        newTicked = ticked.includes(id) ? ticked.filter(function (tickedId) {
+          return tickedId !== id;
+        }) : [].concat(_toConsumableArray(ticked), [id]);
+      } else {
+        newTicked = [id];
+      }
+
+      setTicked(newTicked);
     }
 
-    setTicked(newTicked);
+    if (multiselect) {
+      updatedParents = new Map(parentsTicked);
+    } else {
+      updatedParents = new Map();
+    }
 
     if (parentsTicked.has(id)) {
       updatedParents["delete"](id);
@@ -193,7 +202,8 @@ var TreeViewWithSearch = function TreeViewWithSearch(_ref) {
     multiselect: multiselect,
     ticked: ticked,
     parentsTicked: (0, _utils.adaptMap)(parentsTicked),
-    scrollIntoView: scrollIntoView
+    scrollIntoView: scrollIntoView,
+    allowSelection: allowSelection
   }));
 };
 
@@ -216,7 +226,8 @@ TreeViewWithSearch.propTypes = {
   // preexpanded is a Map
   preexpanded: _propTypes.any,
   selectedData: (0, _propTypes.oneOfType)([_propTypes.object, _propTypes.array]),
-  label: _propTypes.func.isRequired
+  label: _propTypes.func.isRequired,
+  allowSelection: _propTypes.func
 };
 TreeViewWithSearch.defaultProps = {
   getChildrenData: function getChildrenData() {},
@@ -231,5 +242,8 @@ TreeViewWithSearch.defaultProps = {
   multiselect: false,
   preselected: null,
   preexpanded: null,
-  selectedData: []
+  selectedData: [],
+  allowSelection: function allowSelection() {
+    return true;
+  }
 };

--- a/dist/components/Treeview/TreeViewWithSearch.js
+++ b/dist/components/Treeview/TreeViewWithSearch.js
@@ -116,8 +116,6 @@ var TreeViewWithSearch = function TreeViewWithSearch(_ref) {
     var updatedSelectedData;
 
     if (isSelectable) {
-      console.log('OK');
-
       if (multiselect) {
         newTicked = ticked.includes(id) ? ticked.filter(function (tickedId) {
           return tickedId !== id;

--- a/src/components/Treeview/EnrichedTreeItem.js
+++ b/src/components/Treeview/EnrichedTreeItem.js
@@ -176,6 +176,7 @@ const EnrichedTreeItem = ({
             </div>
         );
     }
+    if (!hasChildren && !isSelectable) return null;
     return (
         <div style={{ display: 'flex' }}>
             <TreeItem

--- a/src/components/Treeview/EnrichedTreeItem.js
+++ b/src/components/Treeview/EnrichedTreeItem.js
@@ -23,7 +23,14 @@ const styles = theme => ({
             {
                 backgroundColor: theme.palette.primary.background,
                 alignItems: 'center',
+                color: theme.palette.primary.main,
             },
+    },
+    unselectableTreeItem: {
+        '&.MuiTreeItem-root > .MuiTreeItem-content .MuiTreeItem-label': {
+            alignItems: 'center',
+            color: theme.palette.mediumGray.main,
+        },
     },
     checkbox: {
         color: theme.palette.mediumGray.main,
@@ -46,11 +53,13 @@ const EnrichedTreeItem = ({
     ticked,
     parentsTicked,
     scrollIntoView,
+    allowSelection,
 }) => {
     const classes = useStyles();
     const isExpanded = expanded.includes(id);
     const isTicked = ticked.includes(id);
     const isTickedParent = parentsTicked.includes(id);
+    const isSelectable = allowSelection(data);
     const { data: childrenData, isLoading } = useChildrenData({
         request: fetchChildrenData,
         id,
@@ -87,9 +96,9 @@ const EnrichedTreeItem = ({
             if (!toggleOnLabelClick) {
                 e.preventDefault();
             }
-            onLabelClick(id, data);
+            onLabelClick(id, data, isSelectable);
         },
-        [data, id, onLabelClick, toggleOnLabelClick],
+        [data, id, onLabelClick, toggleOnLabelClick, isSelectable],
     );
 
     useEffect(() => {
@@ -114,13 +123,18 @@ const EnrichedTreeItem = ({
                 ticked={ticked}
                 parentsTicked={parentsTicked}
                 scrollIntoView={scrollIntoView}
+                allowSelection={allowSelection}
             />
         ));
     };
     if (isExpanded && isLoading) {
         return (
             <TreeItem
-                classes={{ root: classes.treeItem }}
+                classes={{
+                    root: isSelectable
+                        ? classes.treeItem
+                        : classes.unselectableTreeItem,
+                }}
                 ref={ref}
                 label={makeLabel(
                     label(data),
@@ -137,7 +151,11 @@ const EnrichedTreeItem = ({
         return (
             <div style={{ display: 'flex' }}>
                 <TreeItem
-                    classes={{ root: classes.treeItem }}
+                    classes={{
+                        root: isSelectable
+                            ? classes.treeItem
+                            : classes.unselectableTreeItem,
+                    }}
                     ref={ref}
                     label={makeLabel(
                         label(data),
@@ -161,7 +179,11 @@ const EnrichedTreeItem = ({
     return (
         <div style={{ display: 'flex' }}>
             <TreeItem
-                classes={{ root: classes.treeItem }}
+                classes={{
+                    root: isSelectable
+                        ? classes.treeItem
+                        : classes.unselectableTreeItem,
+                }}
                 ref={ref}
                 label={makeLabel(label(data), withCheckbox, isTicked)}
                 nodeId={id}
@@ -187,6 +209,7 @@ EnrichedTreeItem.propTypes = {
     ticked: oneOfType([string, array]),
     parentsTicked: array,
     scrollIntoView: string,
+    allowSelection: func,
 };
 
 EnrichedTreeItem.defaultProps = {
@@ -198,6 +221,7 @@ EnrichedTreeItem.defaultProps = {
     ticked: [],
     parentsTicked: [],
     scrollIntoView: null,
+    allowSelection: () => true,
 };
 
 export { EnrichedTreeItem };

--- a/src/components/Treeview/IasoTreeView.js
+++ b/src/components/Treeview/IasoTreeView.js
@@ -40,6 +40,7 @@ const IasoTreeView = ({
     ticked,
     parentsTicked,
     scrollIntoView,
+    allowSelection,
 }) => {
     const classes = useStyles();
     const fetchChildrenData = useCallback(getChildrenData, [getChildrenData]);
@@ -69,6 +70,7 @@ const IasoTreeView = ({
                     ticked={ticked}
                     parentsTicked={parentsTicked}
                     scrollIntoView={scrollIntoView}
+                    allowSelection={allowSelection}
                 />
             ));
         },
@@ -129,6 +131,7 @@ IasoTreeView.propTypes = {
     ticked: oneOfType([string, arrayOf(string)]),
     parentsTicked: array,
     scrollIntoView: string,
+    allowSelection: func,
 };
 
 IasoTreeView.defaultProps = {
@@ -143,6 +146,7 @@ IasoTreeView.defaultProps = {
     ticked: [],
     parentsTicked: [],
     scrollIntoView: null,
+    allowSelection: () => true,
 };
 
 export { IasoTreeView };

--- a/src/components/Treeview/TreeViewWithSearch.js
+++ b/src/components/Treeview/TreeViewWithSearch.js
@@ -39,6 +39,7 @@ const TreeViewWithSearch = ({
     preselected, // TODO rename
     preexpanded, // TODO rename
     selectedData,
+    allowSelection,
 }) => {
     const [data, setData] = useState(formatInitialSelectedData(selectedData));
     const [selected, setSelected] = useState(
@@ -66,20 +67,26 @@ const TreeViewWithSearch = ({
 
     // Tick and untick checkbox
     const onLabelClick = useCallback(
-        (id, itemData) => {
+        (id, itemData, isSelectable) => {
             let newTicked;
             let updatedParents;
             let updatedSelectedData;
+            if (isSelectable) {
+                console.log('OK');
+                if (multiselect) {
+                    newTicked = ticked.includes(id)
+                        ? ticked.filter(tickedId => tickedId !== id)
+                        : [...ticked, id];
+                } else {
+                    newTicked = [id];
+                }
+                setTicked(newTicked);
+            }
             if (multiselect) {
-                newTicked = ticked.includes(id)
-                    ? ticked.filter(tickedId => tickedId !== id)
-                    : [...ticked, id];
                 updatedParents = new Map(parentsTicked);
             } else {
-                newTicked = [id];
                 updatedParents = new Map();
             }
-            setTicked(newTicked);
             if (parentsTicked.has(id)) {
                 updatedParents.delete(id);
                 updatedSelectedData = data.filter(d => d.id !== id);
@@ -153,6 +160,7 @@ const TreeViewWithSearch = ({
                 ticked={ticked}
                 parentsTicked={adaptMap(parentsTicked)}
                 scrollIntoView={scrollIntoView}
+                allowSelection={allowSelection}
             />
         </>
     );
@@ -177,6 +185,7 @@ TreeViewWithSearch.propTypes = {
     preexpanded: any,
     selectedData: oneOfType([object, array]),
     label: func.isRequired,
+    allowSelection: func,
 };
 
 TreeViewWithSearch.defaultProps = {
@@ -193,6 +202,7 @@ TreeViewWithSearch.defaultProps = {
     preselected: null,
     preexpanded: null,
     selectedData: [],
+    allowSelection: () => true,
 };
 
 export { TreeViewWithSearch };

--- a/src/components/Treeview/TreeViewWithSearch.js
+++ b/src/components/Treeview/TreeViewWithSearch.js
@@ -72,7 +72,6 @@ const TreeViewWithSearch = ({
             let updatedParents;
             let updatedSelectedData;
             if (isSelectable) {
-                console.log('OK');
                 if (multiselect) {
                     newTicked = ticked.includes(id)
                         ? ticked.filter(tickedId => tickedId !== id)


### PR DESCRIPTION
## Changes

- add allowSelect prop to `EnrichedTreeItem` & all parents
- update tree item text styling
- add `isSelectable` argument to `TreeviewWithSearch`'s `onLabelClick`
- prevent selection is `isSelectable` is false