### PR TITLE
Pass loading spinner under topbar with default z-index set to 1100

### DIFF
--- a/src/components/LoadingSpinner/index.js
+++ b/src/components/LoadingSpinner/index.js
@@ -20,7 +20,7 @@ const styles = () => ({
     rootFixed: {
         ...baseRoot,
         position: 'fixed',
-        zIndex: '10000',
+        zIndex: '1000',
     },
     rootAbsolute: {
         ...baseRoot,


### PR DESCRIPTION
<img width="841" alt="Screenshot 2022-04-04 at 12 55 16" src="https://user-images.githubusercontent.com/12494624/161529711-7d81331d-1b84-4b4a-94b0-8cff2a4a890f.png">
